### PR TITLE
Change set level to allow for all possible verbosity levels to be set

### DIFF
--- a/logbasecommand/base.py
+++ b/logbasecommand/base.py
@@ -56,8 +56,8 @@ class LogBaseCommand(BaseCommand):
         self.logger.setLevel(
             [
                 logging.ERROR,
-                max(self.logger.getEffectiveLevel(), logging.INFO),
-                logging.DEBUG,
+                logging.INFO,
+                logging.WARNING,
                 logging.DEBUG,
             ][self.verbosity]
         )


### PR DESCRIPTION
Currently we can only set the verbosity level to 

- ERROR
- max between effective level and INFO
- DEBUG
- DEBUG

I think it should be possible to enforce the INFO level or the WARNING level if we wish to do that